### PR TITLE
Added link of Angular Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,4 @@ Have a question about Angular? Shoot me Tweet [@JonathanZWhite](https://twitter.
 - [AngularJS Form Validation](http://scotch.io/tutorials/javascript/angularjs-form-validation)
 - [Angular with FLUX](https://github.com/christianalfoni/flux-angular)
 - [Meligy’s AngularJS & Web Dev Goodies Newsletter - GuruStop.NET](http://gurustop.net/newsletter)
+- [Angular Developer Roadmap](https://roadmap.sh/angular)


### PR DESCRIPTION
Hi @JonathanZWhite,

I came across your repository [AngularJS-Resources](https://github.com/JonathanZWhite/AngularJS-Resources) and found it to be a valuable resource for Angular enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Angular Developer Roadmap"](https://roadmap.sh/angular). I took the initiative to submit a ["Pull Request"](https://github.com/JonathanZWhite/AngularJS-Resources/pull/5) adding it in "Misc" section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz